### PR TITLE
Remove some DraStic specific includes and libraries.

### DIFF
--- a/configure
+++ b/configure
@@ -23125,7 +23125,7 @@ $as_echo "#define SDL_VIDEO_RENDER_MMIYOO 1" >>confdefs.h
         SOURCES="$SOURCES $srcdir/src/video/mmiyoo/*.c"
         have_video=yes
         EXTRA_CFLAGS="$EXTRA_CFLAGS -fPIC -mcpu=cortex-a7 -mfpu=neon-vfpv4 -O3 -I/opt/mmiyoo/arm-buildroot-linux-gnueabihf/sysroot/usr/include/SDL2"
-        EXTRA_LDFLAGS="$EXTRA_LDFLAGS -L. -lEGL -lGLESv2 -lrt -lSDL2_image -lSDL2_ttf -ljson-c"
+        EXTRA_LDFLAGS="$EXTRA_LDFLAGS -L. -lEGL -lGLESv2 -lrt"
         SUMMARY_video="${SUMMARY_video} mmiyoo"
     fi
 }

--- a/configure.ac
+++ b/configure.ac
@@ -2391,7 +2391,7 @@ CheckMMiyooVideo()
         SOURCES="$SOURCES $srcdir/src/video/mmiyoo/*.c"
         have_video=yes
         EXTRA_CFLAGS="$EXTRA_CFLAGS -fPIC -mcpu=cortex-a7 -mfpu=neon-vfpv4 -O3 -I/opt/mmiyoo/arm-buildroot-linux-gnueabihf/sysroot/usr/include/SDL2"
-        EXTRA_LDFLAGS="$EXTRA_LDFLAGS -L. -lEGL -lGLESv2 -lrt -lSDL2_image -lSDL2_ttf -ljson-c"
+        EXTRA_LDFLAGS="$EXTRA_LDFLAGS -L. -lEGL -lGLESv2 -lrt"
         SUMMARY_video="${SUMMARY_video} mmiyoo"
     fi
 }

--- a/sdl2-config.cmake
+++ b/sdl2-config.cmake
@@ -21,7 +21,7 @@ if(NOT TARGET SDL2::SDL2)
   # (SDL2Config.cmake has the same behavior)
   string(REPLACE "-lSDL2main" "" SDL2_EXTRA_LINK_FLAGS ${SDL2_EXTRA_LINK_FLAGS})
   string(STRIP "${SDL2_EXTRA_LINK_FLAGS}" SDL2_EXTRA_LINK_FLAGS)
-  string(REPLACE "-lSDL2 " "" SDL2_EXTRA_LINK_FLAGS_STATIC " -lm -L. -lEGL -lGLESv2 -lrt -lSDL2_image -lSDL2_ttf -ljson-c -ldl -lpthread -lrt -Lmmiyoo/libs -lmi_ao -lshmvar -lmi_common -lmi_sys -lmi_gfx ")
+  string(REPLACE "-lSDL2 " "" SDL2_EXTRA_LINK_FLAGS_STATIC " -lm -L. -lEGL -lGLESv2 -lrt -ldl -lpthread -lrt -Lmmiyoo/libs -lmi_ao -lshmvar -lmi_common -lmi_sys -lmi_gfx ")
   string(STRIP "${SDL2_EXTRA_LINK_FLAGS_STATIC}" SDL2_EXTRA_LINK_FLAGS_STATIC)
 
 if(WIN32 AND NOT MSVC)

--- a/sdl2.pc
+++ b/sdl2.pc
@@ -11,5 +11,5 @@ Version: 2.0.20
 Requires:
 Conflicts:
 Libs: -L${libdir}  -lSDL2 
-Libs.private:  -lm -L. -lEGL -lGLESv2 -lrt -lSDL2_image -lSDL2_ttf -ljson-c -ldl -lpthread -lrt -Lmmiyoo/libs -lmi_ao -lshmvar -lmi_common -lmi_sys -lmi_gfx
+Libs.private:  -lm -L. -lEGL -lGLESv2 -lrt -ldl -lpthread -lrt -Lmmiyoo/libs -lmi_ao -lshmvar -lmi_common -lmi_sys -lmi_gfx
 Cflags: -I${includedir}/SDL2  -D_REENTRANT

--- a/src/video/mmiyoo/SDL_video_mmiyoo.c
+++ b/src/video/mmiyoo/SDL_video_mmiyoo.c
@@ -36,14 +36,12 @@
 #include <sys/ioctl.h>
 #include <sys/time.h>
 #include <time.h>
-#include <json-c/json.h>
 
 #include "../../events/SDL_events_c.h"
 #include "../SDL_sysvideo.h"
 #include "../SDL_sysvideo.h"
 #include "../SDL_pixels_c.h"
 
-#include "SDL_image.h"
 #include "SDL_version.h"
 #include "SDL_syswm.h"
 #include "SDL_loadso.h"

--- a/src/video/mmiyoo/SDL_video_mmiyoo.h
+++ b/src/video/mmiyoo/SDL_video_mmiyoo.h
@@ -33,8 +33,6 @@
 #include "../SDL_pixels_c.h"
 #include "../../events/SDL_events_c.h"
 
-#include "SDL_ttf.h"
-#include "SDL_image.h"
 #include "SDL_version.h"
 #include "SDL_syswm.h"
 #include "SDL_loadso.h"


### PR DESCRIPTION
I think `SDL2_image`, `SDL2_ttf`  and `json-c` are used in the DraStic overlay, making this vanilla SDL a little harder to compile.